### PR TITLE
Update PokeVisionFinder.py (Added catch.txt support)

### DIFF
--- a/PokeVisionFinder.py
+++ b/PokeVisionFinder.py
@@ -25,9 +25,9 @@ _pokemons = []
 _pokemonslisted = []
 
 #PokeSniper2 Configuration
-ps_use = False
-ps_path = "D:\PokemonGO\Sniper\PokeSniper2.exe"
-ps_dir = "D:\PokemonGO\Sniper"
+ps_use = True
+ps_path = ""
+ps_dir = ""
 
 #Clear
 def _clear():
@@ -84,9 +84,10 @@ def _jsondatach(url):
 def _pokename(id):
     return pokemonlist[id-1]
 
-def _pokesplit(pokemons):
-    global _pokemons
-    _pokemons = pokemons.split(",")
+
+#def _pokesplit(pokemons):
+#    global _pokemons
+#    _pokemons = pokemons.split(",")
 
 #POkePrinter
 def _printer(name,lat,lng,exp):
@@ -196,15 +197,27 @@ _inputpoke = ""
 
 _populateCities()
 if len(argv) == 2:
-    _inputpoke = argv[1]
+    # If argv[1] is less than 10 (catch.txt) use file
+    if len(argv[1]) < 10:
+        _inputpoke = [line.strip() for line in open(argv[1], 'r')]
+    # Else the user want to type in manually.
+    else: _inputpoke = argv[1]
 elif len(argv) == 5:
-    _inputpoke = argv[1]
+    if len(argv[1]) < 10:
+        _inputpoke = [line.strip() for line in open(argv[1], 'r')]
+    else: _inputpoke = argv[1]
     _nonstop = int(argv[2]) == 1
     _zoomFactor = float(argv[3])
     _logging = int(argv[4]) == 1
 else:
     _inputpoke = raw_input("Pokemon: ")
-_pokesplit(_inputpoke)
+    
+# Set pokemons to inputpoke,
+# inputpoke is an already parsed list of pokemons
+# from a text file.
+# Use new line to separate each pokemon.
+_pokemons = _inputpoke
+
 if _nonstop:
     while 1:
         _loop()

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# PokeVisionFinder
+# PokeVisionFinder Modfied Edition
+Supports which pokemons to catch in a .txt file.
+![catch.txt illu](http://puu.sh/qlvFQ/1e072d06d4.png)
+![catch.txt illu](http://puu.sh/qlvJy/d21350db3f.png)
+
+
+
 
 Command Line Usage:
 

--- a/catch.txt
+++ b/catch.txt
@@ -12,3 +12,5 @@ alakzam
 growlithe
 arcanine
 charizard
+mewto
+mew

--- a/catch.txt
+++ b/catch.txt
@@ -1,0 +1,14 @@
+charmander
+gyarados
+squirtle
+dratini
+dragonite
+snorlax
+ditto
+lapras
+gyarados
+farfetchd
+alakzam
+growlithe
+arcanine
+charizard


### PR DESCRIPTION
Added support for storing pokemons to catch in a file (in same working directory).

Separate pokemons with a new line.
Save them in catch.txt (the naming can of course be modified, but currently if argv[1] is over 10, it will count as manual input).

This can be cleaned even more up by removing either _pokemons or _inputpoke and just using one list for all of it.
def _pokesplit can also be removed because it's redundant. 
